### PR TITLE
v0.3.4 빌드 결과물 생성

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,8 @@ var year_holidays_1 = require("./year_holidays");
 // 토, 일요일 정보는 포함하지 않음
 var KOREAN_HOLIDAYS = {
     2019: year_holidays_1.HOLIDAYS_2019,
-    2020: year_holidays_1.HOLIDAYS_2020
+    2020: year_holidays_1.HOLIDAYS_2020,
+    2021: year_holidays_1.HOLIDAYS_2021
 };
 function getYmdByDate(date) {
     return {
@@ -15,7 +16,7 @@ function getYmdByDate(date) {
     };
 }
 function getDateFromDayYmd(day_ymd) {
-    if (!/^(2019|2020)(0[1-9]|1[0-2])(0[1-9]|1[0-9]|2[0-9]|3[0-1])$/.test(String(day_ymd))) {
+    if (!/^(2019|2020|2021)(0[1-9]|1[0-2])(0[1-9]|1[0-9]|2[0-9]|3[0-1])$/.test(String(day_ymd))) {
         throw new Error("invalid day_ymd: " + day_ymd);
     }
     var day_m = ("0" + Math.floor(day_ymd / 100 % 100)).slice(-2);

--- a/lib/year_holidays/2021.d.ts
+++ b/lib/year_holidays/2021.d.ts
@@ -1,0 +1,3 @@
+import { IYearHolidays } from '.';
+declare const HOLIDAYS_2020: IYearHolidays;
+export default HOLIDAYS_2020;

--- a/lib/year_holidays/2021.js
+++ b/lib/year_holidays/2021.js
@@ -2,38 +2,35 @@
 exports.__esModule = true;
 var HOLIDAYS_2020 = {
     1: {
-        1: true,
-        24: true,
-        25: true,
-        26: true,
-        27: true
+        1: true
     },
-    2: {},
+    2: {
+        11: true,
+        12: true,
+        13: true
+    },
     3: {
         1: true
     },
-    4: {
-        15: true,
-        30: true
-    },
+    4: {},
     5: {
         1: true,
-        5: true
+        5: true,
+        19: true
     },
     6: {
         6: true
     },
     7: {},
     8: {
-        15: true,
-        17: true
+        15: true
     },
     9: {
-        30: true
+        20: true,
+        21: true,
+        22: true
     },
     10: {
-        1: true,
-        2: true,
         3: true,
         9: true
     },

--- a/lib/year_holidays/index.d.ts
+++ b/lib/year_holidays/index.d.ts
@@ -1,8 +1,9 @@
 import HOLIDAYS_2019 from './2019';
 import HOLIDAYS_2020 from './2020';
+import HOLIDAYS_2021 from './2021';
 interface IYearHolidays {
     [month: number]: {
         [day: number]: boolean;
     };
 }
-export { IYearHolidays, HOLIDAYS_2019, HOLIDAYS_2020, };
+export { IYearHolidays, HOLIDAYS_2019, HOLIDAYS_2020, HOLIDAYS_2021, };

--- a/lib/year_holidays/index.js
+++ b/lib/year_holidays/index.js
@@ -3,8 +3,10 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 exports.__esModule = true;
-exports.HOLIDAYS_2020 = exports.HOLIDAYS_2019 = void 0;
+exports.HOLIDAYS_2021 = exports.HOLIDAYS_2020 = exports.HOLIDAYS_2019 = void 0;
 var _2019_1 = __importDefault(require("./2019"));
 exports.HOLIDAYS_2019 = _2019_1["default"];
 var _2020_1 = __importDefault(require("./2020"));
 exports.HOLIDAYS_2020 = _2020_1["default"];
+var _2021_1 = __importDefault(require("./2021"));
+exports.HOLIDAYS_2021 = _2021_1["default"];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "korean-business-day",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "korean-business-day",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Node module for korean business days",
   "main": "./lib",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
v0.3.4 배포 전에 npm run build의 결과물을 함께 커밋했어야 했는데, 빌드 결과물을 누락했습니다.

1. 이러한 경우에 0.3.5 버전으로 새로 버전을 올리고 publish 하는게 좋을까요?
2. 0.3.4 버전을 deprecate 시키는게 좋을까요?
3. CI 에서 빌드 & 테스트 & 배포 까지 자동으로 하면 좋을 것 같다는 생각이 드네요
