### PR TITLE
배포용 GitHub Action 추가

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: major/minor/patch
+        required: true
+        default: patch
+
+jobs:
+  release:
+
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+
+      - name: Install packages
+        run: npm ci
+
+      - name: Check test pass before releasing
+        run: npm test
+
+      - name: Add release commit
+        run: |
+          git config --global user.name 'croquiscom-admin'
+          git config --global user.email 'admin@croquis.com'
+          npm version --no-git-tag-version ${{ github.event.inputs.version }}
+          npm run build
+          git add package.json package-lock.json lib
+          AUTHOR="${{ github.event.sender.login }} <${{ github.event.sender.id }}+${{ github.event.sender.login }}@users.noreply.github.com>"
+          VERSION=$(node -p "require('./package.json').version")
+          git commit -m "v$VERSION" --author "$AUTHOR"
+          git tag v$VERSION
+          git push
+          git push --tags
+
+      - name: Release version
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -24,13 +24,10 @@ UTC 시간대의 Date 인스턴스를 입력으로 받아 영업일 기준 n일 
 
 1. 소스를 수정하고 테스트 코드를 작성합니다.
 2. `npm test`로 동작 여부를 확인합니다.
-3. `npm run build`로 배포용 소스를 만들어냅니다.
-4. `npm version {major|minor|patch}`로 버전을 올립니다.
-5. `npm publish`로 모듈을 배포합니다.
+3. release workflow를 사용해 모듈을 배포합니다.
 
 # 라이브러리 이력
 [GitHub Releases](https://github.com/croquiscom/korean-business-day/releases)에서 이력을 확인할 수 있습니다.
 
 # 라이선스
-
 MIT licenses. [LICENSE](https://github.com/croquiscom/korean-business-day/blob/master/LICENSE)를 참고하세요.


### PR DESCRIPTION
@neverlish  이런 느낌으로 만들어봤는데 어때보이시나요?
잘 동작할지는 모르겠습니다.

src -> lib 빌드가 안 됐을 때 테스트/배포가 실패하게 할 것인지, 아니면 배포시 빌드를 하도록 하는게 나을지 고민이 됩니다. (현재는 후자입니다)

잘 동작하면 1.0으로 배포할까 싶습니다.